### PR TITLE
Add coverage reporting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         uses: Brightspace/third-party-actions@coverallsapp/github-action
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          flag-name: 'node ${{ matrix.node }}'
+          flag-name: node ${{ matrix.node }}
           parallel: true
   complete-coverage:
     needs: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         node: [ 10, 12, 14 ]
-    name: build (node ${{ matrix.node }})
+    name: Build (node ${{ matrix.node }})
     steps:
       - name: Checkout code
         uses: Brightspace/third-party-actions@actions/checkout
@@ -22,3 +22,19 @@ jobs:
         run: npm i
       - name: Run tests
         run: npm test
+      - name: Report coverage
+        uses: Brightspace/third-party-actions@coverallsapp/github-action
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          flag-name: 'node ${{ matrix.node }}'
+          parallel: true
+  complete-coverage:
+    needs: build
+    runs-on: ubuntu-latest
+    name: Complete coverage
+    steps:
+      - name: Complete coverage
+        uses: Brightspace/third-party-actions@coverallsapp/github-action
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true


### PR DESCRIPTION
This uses the officially built coveralls GitHub action. It does not require a user to be tied to the repository in coveralls system or for coveralls to be installed as a dependency.